### PR TITLE
Strip component prop from Link component on web platform

### DIFF
--- a/src/Routing.web.js
+++ b/src/Routing.web.js
@@ -1,6 +1,12 @@
+import React from "react";
+import { Link } from 'react-router-dom';
+
+const FixedLink = ({ component, children, ...props }) => <Link {...props}>{children}</Link>;
+
+export { FixedLink as Link };
+
 export {
     BrowserRouter as Router,
-    Link,
     Switch,
     Route
 } from 'react-router-dom';

--- a/src/Routing.web.js
+++ b/src/Routing.web.js
@@ -1,7 +1,9 @@
-import React from "react";
+import React from 'react';
 import { Link } from 'react-router-dom';
 
-const FixedLink = ({ component, children, ...props }) => <Link {...props}>{children}</Link>;
+const FixedLink = ({ component, children, ...props }) => (
+    <Link {...props}>{children}</Link>
+);
 
 export { FixedLink as Link };
 


### PR DESCRIPTION
In the navigation-react-router branch I was getting an error:

```
Warning: Invalid value for prop `component` on <a> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM. For details, see https://fb.me/react-attribute-behavior
    in a (created by Link)
    in Link (at App.js:26)
    in div (created by View)
    in View (at App.js:25)
    in Unknown (created by Route)
    in Route (at App.js:59)
    in Switch (at App.js:58)
    in Router (created by BrowserRouter)
    in BrowserRouter (at App.js:57)
    in div (created by View)
    in View (at App.js:47)
    in App (at src/index.js:9)
```

This is because the native platform expects the component prop but web does not. This PR wraps web's Link with a new FixedLink component that just strips away the component prop.